### PR TITLE
feat: enhance exporter architecture with chunked vs full export and context

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,20 @@ jobs:
                 symfony: ["^6.4", "^7.3"]
                 mysql: ["8.4"]
 
+        services:
+            mysql:
+                image: mysql:${{ matrix.mysql }}
+                env:
+                    MYSQL_DATABASE: sylius
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=3
+
         env:
             APP_ENV: test_minimal
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?serverVersion=${{ matrix.mysql }}"
@@ -36,17 +50,6 @@ jobs:
                     extensions: intl
                     tools: symfony
                     coverage: none
-
-            -
-                name: Shutdown default MySQL
-                run: sudo service mysql stop
-
-            -
-                name: Setup MySQL
-                uses: mirromutth/mysql-action@v1.1
-                with:
-                    mysql version: "${{ matrix.mysql }}"
-                    mysql root password: "root"
 
             -
                 name: Get Composer cache directory
@@ -96,13 +99,9 @@ jobs:
                 run: vendor/bin/console lint:container
 
             -
-                name: Warmup cache
-                run: vendor/bin/console cache:warmup
-
-            -
                 name: Setup database
                 run: |
-                    vendor/bin/console doctrine:database:create
+                    vendor/bin/console doctrine:database:create --if-not-exists
                     vendor/bin/console doctrine:schema:create
 
             -

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
 
             -
                 name: Setup MySQL
-                uses: mirromutth/mysql-action@v1.1
+                uses: mirromutth/mysql-action@v1.2
                 with:
                     mysql version: "${{ matrix.mysql }}"
                     mysql root password: "root"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
 
             -
                 name: Setup MySQL
-                uses: mirromutth/mysql-action@v1.2
+                uses: mirromutth/mysql-action@v1.1
                 with:
                     mysql version: "${{ matrix.mysql }}"
                     mysql root password: "root"

--- a/config/services.xml
+++ b/config/services.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="sylius_import_export.repository.process_export" />
             <argument type="service" id="sylius_import_export.export.command_bus" />
             <argument type="service" id="sylius_import_export.export.batched_data_manager" />
+            <argument type="service" id="sylius_import_export.exporter_resolver" />
 
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>

--- a/src/Entity/Process.php
+++ b/src/Entity/Process.php
@@ -25,7 +25,7 @@ abstract class Process implements ProcessInterface
 
     protected string $status;
 
-    protected string $output;
+    protected ?string $output = null;
 
     protected ?string $errorMessage = null;
 
@@ -64,12 +64,12 @@ abstract class Process implements ProcessInterface
         $this->uuid = $uuid;
     }
 
-    public function getOutput(): string
+    public function getOutput(): ?string
     {
         return $this->output;
     }
 
-    public function setOutput(string $output): void
+    public function setOutput(?string $output): void
     {
         $this->output = $output;
     }

--- a/src/Entity/ProcessInterface.php
+++ b/src/Entity/ProcessInterface.php
@@ -32,9 +32,9 @@ interface ProcessInterface extends ResourceInterface, TimestampableInterface
 
     public function setResource(string $resource): void;
 
-    public function getOutput(): string;
+    public function getOutput(): ?string;
 
-    public function setOutput(string $output): void;
+    public function setOutput(?string $output): void;
 
     public function getErrorMessage(): ?string;
 

--- a/src/Exporter/ExporterInterface.php
+++ b/src/Exporter/ExporterInterface.php
@@ -17,5 +17,7 @@ interface ExporterInterface
 {
     public function getConfig(): array;
 
-    public function export(array $data): string;
+    public function supportsBatchedExport(): bool;
+
+    public function export(array $data, array $context): string;
 }

--- a/src/Exporter/ExporterTrait.php
+++ b/src/Exporter/ExporterTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\ImportExport\Exporter;
+
+trait ExporterTrait
+{
+    /**
+     * @param (int[]|string[])[] $data
+     *
+     * @return string[]
+     */
+    private function getHeaders(array $data): array
+    {
+        $firstRow = reset($data) ?: [];
+        $keys = array_keys($firstRow);
+
+        return array_map(static fn (int|string $key) => ucfirst((string) $key), $keys);
+    }
+}

--- a/src/Exporter/JsonExporter.php
+++ b/src/Exporter/JsonExporter.php
@@ -24,7 +24,12 @@ final class JsonExporter extends AbstractExporter
         return self::FORMAT;
     }
 
-    public function export(array $data): string
+    public function supportsBatchedExport(): bool
+    {
+        return false;
+    }
+
+    public function export(array $data, array $context): string
     {
         $filename = $this->generateFilePath(self::FORMAT);
 

--- a/src/Manager/BatchedExportDataManager.php
+++ b/src/Manager/BatchedExportDataManager.php
@@ -14,16 +14,9 @@ declare(strict_types=1);
 namespace Sylius\ImportExport\Manager;
 
 use Sylius\ImportExport\Entity\ExportProcessInterface;
-use Sylius\ImportExport\Exporter\CsvExporter;
-use Sylius\ImportExport\Exporter\JsonExporter;
 
 final class BatchedExportDataManager implements BatchedExportDataManagerInterface
 {
-    private const FILE_BASED_FORMATS = [
-        CsvExporter::FORMAT,
-        JsonExporter::FORMAT,
-    ];
-
     private string $temporaryExportsDirectory;
 
     public function __construct(string $temporaryDirectory)
@@ -33,13 +26,11 @@ final class BatchedExportDataManager implements BatchedExportDataManagerInterfac
 
     public function createStorage(ExportProcessInterface $exportProcess): void
     {
-        if (in_array($exportProcess->getFormat(), self::FILE_BASED_FORMATS)) {
-            $ongoingProcessDirectory = $this->temporaryExportsDirectory . '/' . $exportProcess->getUuid();
-            $exportProcess->setTemporaryDataStorage($ongoingProcessDirectory);
+        $ongoingProcessDirectory = $this->temporaryExportsDirectory . '/' . $exportProcess->getUuid();
+        $exportProcess->setTemporaryDataStorage($ongoingProcessDirectory);
 
-            if (!is_dir($ongoingProcessDirectory)) {
-                mkdir($ongoingProcessDirectory, recursive: true);
-            }
+        if (!is_dir($ongoingProcessDirectory)) {
+            mkdir($ongoingProcessDirectory, recursive: true);
         }
     }
 

--- a/src/Messenger/Command/ExportCommand.php
+++ b/src/Messenger/Command/ExportCommand.php
@@ -18,6 +18,7 @@ class ExportCommand
     public function __construct(
         public string $processId,
         public array $resourceIds,
+        public int $batchIndex,
     ) {
     }
 }

--- a/src/Messenger/Handler/ExportCompletedHandler.php
+++ b/src/Messenger/Handler/ExportCompletedHandler.php
@@ -46,12 +46,11 @@ class ExportCompletedHandler
 
                 $process->setOutput($outputPath);
             }
+            $process->setStatus('success');
         } catch (\Throwable $e) {
             $process->setStatus('failed');
             $process->setErrorMessage($e->getMessage());
         }
-
-        $process->setStatus('success');
 
         $this->batchedDataManager->deleteBatchedData($process);
 

--- a/tests/Functional/Exporting/ExportHandlerTest.php
+++ b/tests/Functional/Exporting/ExportHandlerTest.php
@@ -71,7 +71,7 @@ final class ExportHandlerTest extends FunctionalTestCase
             ['serialization_groups' => $serializationGroup],
         );
 
-        $this->handler->__invoke(new ExportCommand($processUid, $ids));
+        $this->handler->__invoke(new ExportCommand($processUid, $ids, 0));
 
         $files = self::getExportFiles($this->exportsDir);
 


### PR DESCRIPTION
## Changelog

### feat: Pass context into exporter
Add context array with `resourceAlias`, `batchIndex`, `exportFilename` fields, so exporter implementations can perform more complex logic (such as headers, export by template, individual for each resource etc).

### feat: Add ability to choose two strategies for exporter
If `ExporterInterface::supportsBatchedExport()` is `true`, `export()` is called multiple times (once for each data chunk). It is suitable for formats like CSV, each export operation can append new data to the file. This strategy has limitations - it requires that the export queue has only one worker to avoid concurrent write to file.
If it is `false`, all exported data is merged to one array and `export()` is called once with all collected data. This strategy will consume more memory for large datasets.

### feat: CsvExporter can write headers

### fix: Possibility to add custom exporters outside the bundle
Removed `BatchedExportDataManager::FILE_BASED_FORMATS` due to its limitation to internal exporters only.

### fix: Unable to export more than one batch
ExportCompletedHandler: `iterator_to_array(...$batchedData);` replaced by `array_merge(...iterator_to_array($batchedData));`